### PR TITLE
Refactor to use a single pipeline

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
         node: true
     },
     parserOptions: {
-        ecmaVersion: 8,
+        ecmaVersion: 2018,
     },
     rules: {
         'no-console': 'warn',

--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Past Grants Search should return empty results for invalid queries 1`] = `
+Object {
+  "facets": Object {
+    "amountAwarded": Array [],
+    "awardDate": Array [],
+    "grantProgramme": Array [],
+    "orgType": Array [],
+  },
+  "meta": Object {
+    "pagination": Object {
+      "currentPage": 1,
+      "perPageCount": 50,
+      "skipCount": 0,
+      "totalPages": 0,
+    },
+    "totalResults": 0,
+  },
+  "results": Array [],
+}
+`;

--- a/grants/search.js
+++ b/grants/search.js
@@ -216,7 +216,7 @@ async function fetchGrants(collection, queryParams) {
      * e.g. totalResults: [{ count: 123456 }]
      * so we need to pluck out the single value
      */
-    const totalResultsValue = head(totalResults).count;
+    const totalResultsValue = totalResults.length > 0 ? head(totalResults).count : 0;
 
     return {
         meta: {

--- a/grants/search.test.js
+++ b/grants/search.test.js
@@ -35,7 +35,7 @@ describe('Past Grants Search', () => {
         const grants = await queryGrants({
             q: 'youth'
         });
-        expect(grants.results.length).toBe(5);
+        expect(grants.results.length).toBe(1);
     });
 
     it('should find grants by programme', async () => {
@@ -70,12 +70,13 @@ describe('Past Grants Search', () => {
     });
 
     it('should return empty results for invalid queries', async () => {
-        const grants = await queryGrants({
+        const result = await queryGrants({
             orgType: 'MadeUpOrg',
             q: 'purple monkey dishwasher',
             programme: 'Big Cheese Fund',
             postcode: 'N1 9GU'
         });
-        expect(grants.results.length).toBe(0);
+
+        expect(result).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
I was looking to improve the text search by requiring results to have a minimum weight:

```
{ $match: { _textScore: { $gt: 1.0 } } }
```

Noticed that our current approach for getting totals, results, and facets means that not all queries are supported across all three so the total results counts can end up wrong.

Reading the docs a bit more it turns out that the whole point of `$facet` is that it lets you perform a single pipeline query for everything you need.

The only caveat to note is that because `$facet` returns everything in arrays we need to do a little massaging work at the end to keep the same json response as before.