### PR TITLE
Improve querying

### DIFF
--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -17,6 +17,12 @@ Object {
       "skipCount": 0,
       "totalPages": 0,
     },
+    "query": Object {
+      "orgType": "MadeUpOrg",
+      "postcode": "N1 9GU",
+      "programme": "Big Cheese Fund",
+      "q": "\\"purple\\" \\"monkey\\" \\"dishwasher\\"",
+    },
     "totalResults": 0,
   },
   "results": Array [],

--- a/grants/search.js
+++ b/grants/search.js
@@ -34,6 +34,14 @@ async function buildMatchCriteria(queryParams) {
     }
 
     if (queryParams.q && !isPostcode(queryParams.q)) {
+        queryParams.q = queryParams.q.split(' ').map(t => {
+            // Is this a negation? Don't wrap it in quotes
+            if (t[0] === '-') {
+                return t;
+            }
+            return `"${t}"`;
+        }).join(' ');
+
         match.$text = {
             $search: queryParams.q
         };
@@ -292,6 +300,7 @@ async function fetchGrants(collection, queryParams) {
     return {
         meta: {
             totalResults: totalResults,
+            query: queryParams,
             pagination: {
                 currentPage: currentPage,
                 perPageCount: perPageCount,

--- a/grants/search.js
+++ b/grants/search.js
@@ -34,13 +34,15 @@ async function buildMatchCriteria(queryParams) {
     }
 
     if (queryParams.q && !isPostcode(queryParams.q)) {
-        queryParams.q = queryParams.q.split(' ').map(t => {
-            // Is this a negation? Don't wrap it in quotes
-            if (t[0] === '-') {
-                return t;
-            }
-            return `"${t}"`;
-        }).join(' ');
+        if (queryParams.q.indexOf('"') === -1) {
+            queryParams.q = queryParams.q.split(' ').map(t => {
+                // Is this a negation? Don't wrap it in quotes
+                if (t[0] === '-') {
+                    return t;
+                }
+                return `"${t}"`;
+            }).join(' ');
+        }
 
         match.$text = {
             $search: queryParams.q

--- a/grants/search.test.js
+++ b/grants/search.test.js
@@ -95,4 +95,11 @@ describe('Past Grants Search', () => {
         });
         expect(result.meta.query.q).toEqual('"led" "zeppelin" -airships');
     });
+
+    it('should not modify already-quoted words when quoting query strings', async () => {
+        const result = await queryGrants({
+            q: '"cause you know sometimes words have two meanings"',
+        });
+        expect(result.meta.query.q).toEqual('"cause you know sometimes words have two meanings"');
+    });
 });

--- a/grants/search.test.js
+++ b/grants/search.test.js
@@ -81,4 +81,18 @@ describe('Past Grants Search', () => {
 
         expect(result).toMatchSnapshot();
     });
+
+    it('should convert multi-word queries into quoted strings', async () => {
+        const result = await queryGrants({
+            q: 'led zeppelin',
+        });
+        expect(result.meta.query.q).toEqual('"led" "zeppelin"');
+    });
+
+    it('should not modify negated words when quoting query strings', async () => {
+        const result = await queryGrants({
+            q: 'led zeppelin -airships',
+        });
+        expect(result.meta.query.q).toEqual('"led" "zeppelin" -airships');
+    });
 });


### PR DESCRIPTION
This change (credit to @davidrapson) wraps search words in quotes to ensure each term appears in the search result. This change means much fewer results for queries, eg:

![image](https://user-images.githubusercontent.com/394376/46345429-764e9900-c63c-11e8-8683-49f642d6b68a.png)

(but hopefully more accurate results!)

This also allows for negation, eg. if a term is prefixed with `-` then it isn't wrapped (which breaks the negation):

![image](https://user-images.githubusercontent.com/394376/46345495-aac25500-c63c-11e8-8f9f-bef951470cc2.png)
