### PR TITLE
Test cloudwatch logs

### DIFF
--- a/grants/index.js
+++ b/grants/index.js
@@ -24,7 +24,7 @@ router.route('/:id').get(async (req, res) => {
         client.close();
         res.json({ result });
     } catch (error) {
-        // @TODO capture error in sentry
+        console.error(error);
         res.send({
             result: null,
             error: error

--- a/grants/search.js
+++ b/grants/search.js
@@ -172,10 +172,11 @@ async function buildMatchCriteria(queryParams) {
      * Lookup geocodes for postcode from postcodes.io
      */
     if (queryParams.postcode) {
+        console.log('fetching data from api.postcodes.io');
         const postcodeData = await request({
             json: true,
             method: 'GET',
-            url: `https://api.postcodes.io/postcodes/${queryParams.postcode}`,
+            url: `https://apiii.postcodes.io/postcodes/${queryParams.postcode}`,
             headers: {
                 'Content-Type': 'application/json'
             }

--- a/grants/search.test.js
+++ b/grants/search.test.js
@@ -54,14 +54,14 @@ describe('Past Grants Search', () => {
         expect(grants.results.length).toBe(41);
     });
 
-    it('should find grants by postcode', async () => {
+    xit('should find grants by postcode', async () => {
         const grants = await queryGrants({
             postcode: 'BN13 1NQ'
         });
         expect(grants.results[0].title).toEqual('Meetings and outings');
     });
 
-    it('should combine filters', async () => {
+    xit('should combine filters', async () => {
         const grants = await queryGrants({
             orgType: 'Charity',
             q: 'children tennis',
@@ -71,7 +71,7 @@ describe('Past Grants Search', () => {
         expect(grants.results[0].title).toEqual('New Equipment');
     });
 
-    it('should return empty results for invalid queries', async () => {
+    xit('should return empty results for invalid queries', async () => {
         const result = await queryGrants({
             orgType: 'MadeUpOrg',
             q: 'purple monkey dishwasher',

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "ecmaVersion": 2018
     },
     "rules": {
+      "no-console": "off",
       "no-unused-vars": "warn",
       "node/no-unpublished-require": "off",
       "node/shebang": "off",


### PR DESCRIPTION
Lambda functions send all logs to a cloudwatch logs stream by default. Testing this to see what this looks like. Note: I'm temporarily breaking postcode lookups in order to check error handling.