### PR TITLE
Enhance facets

### DIFF
--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "facets": Object {
     "amountAwarded": Array [],
     "awardDate": Array [],
+    "countries": Array [],
     "grantProgramme": Array [],
     "localAuthorities": Array [],
     "orgType": Array [],

--- a/grants/search.js
+++ b/grants/search.js
@@ -418,7 +418,7 @@ async function fetchGrants(collection, queryParams) {
         .toArray();
 
     /**
-     * Peform a second query with $facet pipelines
+     * Perform a second query with $facet pipelines
      * No limit or skip set as we want facets for the full result set.
      */
     const facetsResult = await collection
@@ -481,7 +481,7 @@ async function fetchGrants(collection, queryParams) {
 
 
     /**
-     * Peform a separate (fast) count query to get the total results.
+     * Perform a separate (fast) count query to get the total results.
      */
     const totalResults = await collection.find(matchCriteria).count();
 


### PR DESCRIPTION
Adds some new facets (or tweaks existing ones) to aid with https://github.com/biglotteryfund/blf-alpha/pull/1336

- We now have a country facet:

![image](https://user-images.githubusercontent.com/394376/46468075-66af8b80-c7c7-11e8-8472-5227721989e9.png)

- Amount awarded now generates its strings / query parameters on the API side:

![image](https://user-images.githubusercontent.com/394376/46468102-7929c500-c7c7-11e8-8f88-5586b7d499e1.png)

This will make UI rendering easier (and in the case of countries, dynamic, like the other facet filters)