### PR TITLE
More past grant search improvements

### DIFF
--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -26,7 +26,6 @@ Object {
     },
     "query": Object {
       "orgType": "MadeUpOrg",
-      "postcode": "N1 9GU",
       "programme": "Big Cheese Fund",
       "q": "\\"purple\\" \\"monkey\\" \\"dishwasher\\"",
     },

--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -30,6 +30,7 @@ Object {
       "programme": "Big Cheese Fund",
       "q": "\\"purple\\" \\"monkey\\" \\"dishwasher\\"",
     },
+    "totalAwarded": false,
     "totalResults": 0,
     "usingFacetCache": false,
   },

--- a/grants/search.js
+++ b/grants/search.js
@@ -48,7 +48,7 @@ const GEOCODE_TYPES = {
  * @param {string} input
  */
 function isPostcode(input) {
-    return input.match(/(gir\s?0aa|[a-zA-Z]{1,2}\d[\da-zA-Z]?\s?(\d[a-zA-Z]{2})?)/);
+    return input && input.match(/(gir\s?0aa|[a-zA-Z]{1,2}\d[\da-zA-Z]?\s?(\d[a-zA-Z]{2})?)/);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=8.3.0"
   },
   "scripts": {
-    "start": "sls offline start",
+    "start": "sls offline start --dontPrintOutput",
     "test": "eslint . && jest --detectOpenHandles",
     "format": "prettier --single-quote --write *.js *.yml {grants,lib}/**/*.js README.md",
     "deployTest": "sls deploy --stage=test --region=eu-west-2",


### PR DESCRIPTION
Few things here:

We calculate the total amount awarded:

![image](https://user-images.githubusercontent.com/394376/46604339-d4bcc100-caed-11e8-800e-30dcdfabad26.png)

Did some work on matching partial postcodes (eg. `B30`) – our regex allows these, but the postcode API endpoint expects a full one. Tweaked it to make it a query instead (eg. which will match both types).

Also tweaked the postcode matching to allow a mixed query (eg. `B30 cats`) – this will find the postcode, remove it from the query (eg. leaving `cats`) and then search by location, meaning users won't get an error on the frontend if they search with a postcode and a term (and they'll get results, too!).

This also stops Serverless from spamming the console with JSON.

Pairs with https://github.com/biglotteryfund/blf-alpha/pull/1352
