### PR TITLE
Improve import scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@ Once you've done this and have confirmed it works as expected, you can push the 
 
 1. Export your local Mongo database:
 
-    `./scripts/export-local <path-to-backup-directory>`
+    `./scripts/export-local <path-to-backup-directory> <name-of-local-collection>`
 
 2. Restore this backup to the remote Mongo instance:
 
-    `./scripts/import-remote "list,of,hostnames" <path-to-backup-directory> "new-collection-name"`
+    `./scripts/import-remote "list,of,hostnames" <path-to-backup-directory> "local-collection_name" "new-collection-name"`
 
     Note: you'll need access to the remote Mongo Cloud team account to get the hostnames/passwords required for this command.
 

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,5 +1,6 @@
 'use strict';
 const { MongoClient } = require('mongodb');
+require('dotenv').config();
 
 async function connectToMongo() {
     try {

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -142,7 +142,12 @@ const fixEncodingIssues = data => {
         if (hasBrokenTitle) {
             data.title = data.title.replace(wrong, right);
         }
+        const hasBrokenDescription = data.description.match(wrong);
+        if (hasBrokenDescription) {
+            data.description = data.description.replace(wrong, right);
+        }
     });
+
     return data;
 };
 

--- a/scripts/create-indices
+++ b/scripts/create-indices
@@ -12,7 +12,7 @@ const indices = require('../lib/indices');
         await Promise.all(indices.map(index => {
             return grantsCollection.createIndex(index.spec, index.options)
         }));
-        console.log('Indices were created');
+        console.log(`Indices were created for ${process.env.MONGO_COLLECTION}`);
         process.exit(0);
     } catch (error) {
         console.log(error);

--- a/scripts/export-local
+++ b/scripts/export-local
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 BACKUP_DIR=$1
+COLLECTION=$2
 
 if [ -z "$1" ]
   then
@@ -8,9 +9,15 @@ if [ -z "$1" ]
     exit 1
 fi
 
-mongodump --db blf --collection grants --out "$BACKUP_DIR"
+if [ -z "$2" ]
+  then
+    echo "Second argument should be the name of the local collection to back up"
+    exit 1
+fi
+
+mongodump --db blf --collection "$COLLECTION" --out "$BACKUP_DIR"
 
 echo "Dump completed!"
 echo "To upload this export to the remote Mongo instance, use the following command:"
 echo ""
-echo "./scripts/import-remote \"list,of,hostnames\"" $BACKUP_DIR "new-collection-name"
+echo "./scripts/import-remote \"list,of,hostnames\"" $BACKUP_DIR "local-collection_name" "new-collection-name"

--- a/scripts/import-csv
+++ b/scripts/import-csv
@@ -39,3 +39,4 @@ echo "Importing grant data into '$COLLECTION_NAME' collection in database '$DATA
 rm tmp-parsed.json tmp-clean.json;
 echo "Cleanup complete";
 echo "CSV import successful!";
+echo "If this is a new database, point your local app at it and create the indices."

--- a/scripts/import-remote
+++ b/scripts/import-remote
@@ -2,7 +2,8 @@
 
 HOSTNAMES=$1
 BACKUP_DIR=$2
-TMP_NAME=$3
+SRC_COLL=$3
+DEST_COLL=$4
 
 if [ -z "$1" ]
   then
@@ -19,12 +20,19 @@ fi
 
 if [ -z "$3" ]
   then
-    echo "Third argument should be a name for the newly-created database"
+    echo "Third argument should be the name of the local collection in the backup directory"
     exit 1
 fi
 
-DEST_COLLECTION=blf.$TMP_NAME
+if [ -z "$4" ]
+  then
+    echo "Fourth argument should be the desired name of the new remote collection"
+    exit 1
+fi
 
-mongorestore --host "$HOSTNAMES" --ssl --sslAllowInvalidHostnames --username biglotteryfund --authenticationDatabase admin --nsInclude 'blf.*' --nsFrom 'blf.grants' --nsTo $DEST_COLLECTION "$BACKUP_DIR"
+SOURCE_COLLECTION=blf.$SRC_COLL
+DEST_COLLECTION=blf.$DEST_COLL
+
+mongorestore --host "$HOSTNAMES" --ssl --sslAllowInvalidHostnames --username biglotteryfund --authenticationDatabase admin --nsInclude 'blf.*' --nsFrom $SOURCE_COLLECTION --nsTo $DEST_COLLECTION "$BACKUP_DIR"
 
 echo "Import successful! Now go and check the data is correct, and cut over to the new collection ($DEST_COLLECTION)"


### PR DESCRIPTION
Added some steps here to make it easier to export a local database to a custom collection name and then output it to a different collection name, too.

Convention I'm going with for exporting to production db = `grants-2018-10-11`.