### PR TITLE
Enhance facets

### DIFF
--- a/grants/__snapshots__/search.test.js.snap
+++ b/grants/__snapshots__/search.test.js.snap
@@ -8,7 +8,7 @@ Object {
     "countries": Array [],
     "grantProgramme": Array [],
     "localAuthorities": Array [],
-    "orgType": Array [],
+    "orgType": Object {},
     "westminsterConstituencies": Array [],
   },
   "meta": Object {

--- a/grants/search.js
+++ b/grants/search.js
@@ -38,8 +38,7 @@ function addActiveStatus(grant) {
     const endDate = get(grant, 'plannedDates[0].endDate', false);
 
     if (endDate) {
-        const endsBeforeNow = moment(endDate).isBefore(moment());
-        grant.isActive = endsBeforeNow;
+        grant.isActive = !moment(endDate).isBefore(moment());
     }
 
     return grant;

--- a/grants/search.js
+++ b/grants/search.js
@@ -445,6 +445,9 @@ async function fetchFacets(collection, matchCriteria = {}) {
     });
 
 
+    // Clean up orgTypes
+    facets.orgType = facets.orgType.filter(f => !!f._id);
+
     // Strip out empty locations from missing geocodes
     facets.countries = facets.countries.filter(f => !!f._id);
     facets.localAuthorities = facets.localAuthorities.filter(f => !!f._id);

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -187,6 +187,7 @@ const fixEncodingIssues = data => {
         [/â€“/g, "–"],
         [/â€¦/g, "…"],
         [/â€œ/g, '"'],
+        [/Â£/g, '£'],
         [/â€/g, '"'], // must come last, otherwise too general
     ];
     encodingFixes.forEach(pair => {

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -18,6 +18,25 @@ const argv = require('yargs')
     .help('h')
     .alias('h', 'help').argv;
 
+const COUNTRIES = {
+    england: {
+        pattern: /^E/,
+        title: 'England'
+    },
+    wales: {
+        pattern: /^W/,
+        title: 'Wales'
+    },
+    scotland: {
+        pattern: /^S/,
+        title: 'Scotland'
+    },
+    'northern-ireland': {
+        pattern: /^N/,
+        title: 'Northern Ireland'
+    }
+};
+
 // Turn date fields into actual Date objects
 const parseDates = data => {
     const dateFields = [
@@ -98,6 +117,19 @@ const rename = data => {
         dateModified: data['Last modified']
     };
 
+    function getCountryName(geocode) {
+        let countryName, isValid;
+        for (let countryKey in COUNTRIES) {
+            const country = COUNTRIES[countryKey];
+            isValid = country.pattern.test(geocode);
+            if (isValid) {
+                countryName = country.title;
+                break;
+            }
+        }
+        return countryName;
+    }
+
     // Some records have no location, so only add that field if we find one
     if (data['Recipient Org:Location:0:Name'] && data['Recipient Org:Location:0:Name'] !== '') {
         // Add the first location (always a ward code)
@@ -109,16 +141,21 @@ const rename = data => {
             }
         ];
 
-        // There's a slim possibility a record has one location, but not the second
+        // There's a slim possibility a record has one location, but not a second
         // So add the local authority if we have one
         if (data['Recipient Org:Location:1:Name'] && data['Recipient Org:Location:1:Name'] !== '') {
-            newData.beneficiaryLocation.push(
-                {
-                    name: data['Recipient Org:Location:1:Name'],
-                    geoCode: data['Recipient Org:Location:1:Geographic Code'],
-                    geoCodeType: 'CMLAD'
-                }
-            );
+            const ladGeoCode = data['Recipient Org:Location:1:Geographic Code'];
+            let localAuthorityData = {
+                name: data['Recipient Org:Location:1:Name'],
+                geoCode: ladGeoCode,
+                geoCodeType: 'CMLAD'
+            };
+            // Add the country name (if valid) for later filtering
+            const countryName = getCountryName(ladGeoCode);
+            if (countryName) {
+                localAuthorityData.country = countryName;
+            }
+            newData.beneficiaryLocation.push(localAuthorityData);
         }
     }
 


### PR DESCRIPTION
A few things here:

- Adds the country name to the geocodes (this breaks the GrantNav standard a bit, but they don't allow us to differentiate between Wales/Scotland/England/NI, sooooo...) so we don't need to regex search

- Changes the `orgType` facet to be an object of arrays keyed by parent category, eg:

![image](https://user-images.githubusercontent.com/394376/47145071-ca09e500-d2c0-11e8-91cb-49e2075c65d1.png)

This will break the frontend until we adapt the facet component to be an `optgroup` – think we need your new branch to be merged first @davidrapson?

- A couple of minor cleanups (fix broken encoding again, and fix a broken active status checker).
