### PR TITLE
Exclude common words from queries

### DIFF
--- a/grants/search.js
+++ b/grants/search.js
@@ -596,12 +596,14 @@ async function fetchFacets(collection, matchCriteria = {}, locale, grantResults 
             }
         ];
         const newestGrant = head(sortBy(grantResults, 'awardDate').reverse());
-        const monthsAgo = now.diff(moment(newestGrant.awardDate), 'months');
-        additionalDateOptions.forEach(dateOpt => {
-            if (dateOpt.number > monthsAgo) {
-                facets.awardDate.unshift(makeDateOption(dateOpt))
-            }
-        });
+        if (newestGrant) {
+            const monthsAgo = now.diff(moment(newestGrant.awardDate), 'months');
+            additionalDateOptions.forEach(dateOpt => {
+                if (dateOpt.number > monthsAgo) {
+                    facets.awardDate.unshift(makeDateOption(dateOpt))
+                }
+            });
+        }
     }
 
 


### PR DESCRIPTION
Excludes words like "project" if possible to avoid DB strain.

Also dynamically calculates whether `3/6 month ago` date ranges should be shown.