### PR TITLE
Make sure we include recent award dates for cached facets

### DIFF
--- a/grants/index.js
+++ b/grants/index.js
@@ -31,12 +31,18 @@ router.route('/').get(async (req, res) => {
 router.get('/build-facets', async (req, res) => {
     try {
         const mongo = await connectToMongo();
-        const resultsEn = await fetchFacets(mongo.grantsCollection, {
-            awardDate: { $exists: true }
+
+        const latestGrant = await fetchGrants(mongo, {
+            limit: 1,
+            sort: 'awardDate|desc'
         });
-        const resultsCy = await fetchFacets(mongo.grantsCollection, {
+
+        const getFacets = async locale => fetchFacets(mongo.grantsCollection, {
             awardDate: { $exists: true }
-        }, 'cy');
+        }, locale, latestGrant);
+
+        const resultsEn = await getFacets('en');
+        const resultsCy = await getFacets('cy');
 
         await mongo.facetsCollection.insertOne({
             en: resultsEn,

--- a/grants/search.js
+++ b/grants/search.js
@@ -589,13 +589,13 @@ async function fetchFacets(collection, matchCriteria = {}, locale, grantResults 
         };
         const additionalDateOptions = [
             {
+                number: 6,
+                name: 'six'
+            },
+            {
                 number: 3,
                 name: 'three'
             },
-            {
-                number: 6,
-                name: 'six'
-            }
         ];
         const newestGrant = head(sortBy(grantResults, 'awardDate').reverse());
         if (newestGrant) {


### PR DESCRIPTION
Forgot that the facets now need to be passed the query results so we can determine whether we should show the 3/6 month options. For cached facets we now pass the most recent grant, which determines whether we show these options. Also reversed them so they display properly (eg. 3 then 6 months)