### PR TITLE
Improve index for location queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Once you've done this and have confirmed it works as expected, you can push the 
 
 ```
 ./scripts/import-remote "list,of,hostnames" <path-to-backup-directory> "local-collection_name" "new-collection-name"
-````
+```
 
 > Note: you'll need access to the remote Mongo Cloud team account to get the hostnames/passwords required for this command.
 

--- a/grants/index.js
+++ b/grants/index.js
@@ -19,7 +19,8 @@ router.route('/').get(async (req, res) => {
     try {
         res.locals.timings.start('fetch-grants');
         const mongo = await connectToMongo();
-        const results = await fetchGrants(mongo, req.query);
+        const { locale, ...queryParams } = req.query;
+        const results = await fetchGrants(mongo, locale, queryParams);
         mongo.client.close();
         res.locals.timings.end('fetch-grants');
         res.json(results);
@@ -37,7 +38,7 @@ router.get('/build-facets', async (req, res) => {
     try {
         const mongo = await connectToMongo();
 
-        const latestGrant = await fetchGrants(mongo, {
+        const latestGrant = await fetchGrants(mongo, 'en', {
             limit: 1,
             sort: 'awardDate|desc'
         });

--- a/grants/search.test.js
+++ b/grants/search.test.js
@@ -37,7 +37,7 @@ describe('Past Grants Search', () => {
 
     // Convenience method for querying directly without passing a collection
     const queryGrants = async query =>
-        fetchGrants({ grantsCollection, facetsCollection }, query);
+        fetchGrants({ grantsCollection, facetsCollection }, 'en', query);
 
     it('should find grants by text search', async () => {
         const grants = await queryGrants({

--- a/lib/indices.js
+++ b/lib/indices.js
@@ -42,18 +42,22 @@ module.exports = [
         options: { name: 'recipientOrganizationId' }
     },
     {
-        "spec": {
-            "amountAwarded": 1,
-            "awardDate": 1,
+        spec: { 'beneficiaryLocation.geoCode': 1 },
+        options: { name: 'geoCode' }
+    },
+    {
+        spec: {
+            amountAwarded: 1,
+            awardDate: 1,
             'grantProgramme.title': 1,
-            "beneficiaryLocation.country": 1,
+            'beneficiaryLocation.country': 1,
             'beneficiaryLocation.geoCode': 1,
             'beneficiaryLocation.geoCodeType': 1,
-            "recipientOrganization.organisationType": 1,
-            "recipientOrganization.organisationSubtype": 1
+            'recipientOrganization.organisationType': 1,
+            'recipientOrganization.organisationSubtype': 1
         },
-        "options": {
-            "name": "FacetIndex"
+        options: {
+            name: 'FacetIndex'
         }
     }
 ];

--- a/translations.js
+++ b/translations.js
@@ -3,9 +3,9 @@ const { get } = require('lodash');
 
 const translations = {
     misc: {
-        'Under': {
+        Under: {
             en: 'Under',
-            cy: 'O dan',
+            cy: 'O dan'
         },
         'Last six months': {
             en: 'Last six months',
@@ -19,274 +19,271 @@ const translations = {
     sortOptions: {
         'Most recent': {
             en: 'Most recent',
-            cy: 'Mwyaf diweddar',
+            cy: 'Mwyaf diweddar'
         },
         'Oldest first': {
             en: 'Oldest first',
-            cy: 'Hynaf yn gyntaf',
+            cy: 'Hynaf yn gyntaf'
         },
         'Lowest amount first': {
             en: 'Lowest amount first',
-            cy: 'Swm isaf yn gyntaf',
+            cy: 'Swm isaf yn gyntaf'
         },
         'Highest amount first': {
             en: 'Highest amount first',
-            cy: 'Swm uchaf yn gyntaf',
+            cy: 'Swm uchaf yn gyntaf'
         },
         'Most relevant': {
             en: 'Most relevant',
-            cy: 'Mwyaf perthnasol',
+            cy: 'Mwyaf perthnasol'
         }
     },
     countries: {
-        'England': {
+        England: {
             en: 'England',
-            cy: 'Lloegr',
+            cy: 'Lloegr'
         },
-        'Scotland': {
+        Scotland: {
             en: 'Scotland',
-            cy: 'Yr Alban',
+            cy: 'Yr Alban'
         },
         'Northern Ireland': {
             en: 'Northern Ireland',
-            cy: 'Gogledd Iwerddon',
+            cy: 'Gogledd Iwerddon'
         },
-        'Wales': {
+        Wales: {
             en: 'Wales',
-            cy: 'Cymru',
-        },
+            cy: 'Cymru'
+        }
     },
-    localAuthorities: {
-
-    },
-    westminsterConstituencies: {
-
-    },
+    localAuthorities: {},
+    westminsterConstituencies: {},
     orgTypes: {
-        "Charity": {
-            "en": "Charity",
-            "cy": "Elusen"
+        Charity: {
+            en: 'Charity',
+            cy: 'Elusen'
         },
-        "Charity: All": {
-            "en": "Charity: All",
-            "cy": "Elusen: Pob un"
+        'Charity: All': {
+            en: 'Charity: All',
+            cy: 'Elusen: Pob un'
         },
-        "Charitable Incorporated Organisation": {
-            "en": "Charitable Incorporated Organisation",
-            "cy": "Mudiad Elusennol Corfforedig"
+        'Charitable Incorporated Organisation': {
+            en: 'Charitable Incorporated Organisation',
+            cy: 'Mudiad Elusennol Corfforedig'
         },
-        "Charitable Trust": {
-            "en": "Charitable Trust",
-            "cy": "Ymddiriedolaeth Elusennol"
+        'Charitable Trust': {
+            en: 'Charitable Trust',
+            cy: 'Ymddiriedolaeth Elusennol'
         },
-        "Charitable Unincorporated Association": {
-            "en": "Charitable Unincorporated Association",
-            "cy": "Cymdeithas Elusennol Anghorfforedig"
+        'Charitable Unincorporated Association': {
+            en: 'Charitable Unincorporated Association',
+            cy: 'Cymdeithas Elusennol Anghorfforedig'
         },
-        "Charity (Royal Charter or Act of Parliament)": {
-            "en": "Charity (Royal Charter or Act of Parliament)",
-            "cy": "Elusen (Siarter Brenhinol neu Ddeddf Seneddol)"
+        'Charity (Royal Charter or Act of Parliament)': {
+            en: 'Charity (Royal Charter or Act of Parliament)',
+            cy: 'Elusen (Siarter Brenhinol neu Ddeddf Seneddol)'
         },
-        "Excepted Charity": {
-            "en": "Excepted Charity",
-            "cy": "Elusen Eithriedig"
+        'Excepted Charity': {
+            en: 'Excepted Charity',
+            cy: 'Elusen Eithriedig'
         },
-        "Exempt Charity": {
-            "en": "Exempt Charity",
-            "cy": "Elusen Ddi-dreth"
+        'Exempt Charity': {
+            en: 'Exempt Charity',
+            cy: 'Elusen Ddi-dreth'
         },
-        "Registered Charity": {
-            "en": "Registered Charity",
-            "cy": "Elusen Gofrestredig"
+        'Registered Charity': {
+            en: 'Registered Charity',
+            cy: 'Elusen Gofrestredig'
         },
-        "Company/Mutual Society": {
-            "en": "Company/Mutual Society",
-            "cy": "Cwmni/Cymdeithas Gydfuddiannol"
+        'Company/Mutual Society': {
+            en: 'Company/Mutual Society',
+            cy: 'Cwmni/Cymdeithas Gydfuddiannol'
         },
-        "Company/Mutual Society: All": {
-            "en": "Company/Mutual Society: All",
-            "cy": "Cwmni/Cymdeithas Gydfuddiannol: Pob un"
+        'Company/Mutual Society: All': {
+            en: 'Company/Mutual Society: All',
+            cy: 'Cwmni/Cymdeithas Gydfuddiannol: Pob un'
         },
-        "Company - Limited by Shares": {
-            "en": "Company - Limited by Shares",
-            "cy": "Cwmni - Cyfyngedig trwy Gyfranddaliadau"
+        'Company - Limited by Shares': {
+            en: 'Company - Limited by Shares',
+            cy: 'Cwmni - Cyfyngedig trwy Gyfranddaliadau'
         },
-        "CIC - Limited by Guarantee": {
-            "en": "CIC - Limited by Guarantee",
-            "cy": "CBC - Cyfyngedig trwy Warant"
+        'CIC - Limited by Guarantee': {
+            en: 'CIC - Limited by Guarantee',
+            cy: 'CBC - Cyfyngedig trwy Warant'
         },
-        "CIC - Limited by Shares": {
-            "en": "CIC - Limited by Shares",
-            "cy": "CBC - Cyfyngedig trwy Gyfranddaliadau"
+        'CIC - Limited by Shares': {
+            en: 'CIC - Limited by Shares',
+            cy: 'CBC - Cyfyngedig trwy Gyfranddaliadau'
         },
-        "CIC - Listed Publicly": {
-            "en": "CIC - Listed Publicly",
-            "cy": "CBC - Wedi'i Restru'n Gyhoeddus"
+        'CIC - Listed Publicly': {
+            en: 'CIC - Listed Publicly',
+            cy: "CBC - Wedi'i Restru'n Gyhoeddus"
         },
-        "Co-operative - unincorporated": {
-            "en": "Co-operative - unincorporated",
-            "cy": "Cydweithfa - anghorfforedig"
+        'Co-operative - unincorporated': {
+            en: 'Co-operative - unincorporated',
+            cy: 'Cydweithfa - anghorfforedig'
         },
-        "Company - Limited by Guarantee": {
-            "en": "Company - Limited by Guarantee",
-            "cy": "Cwmni - Cyfyngedig trwy Warant"
+        'Company - Limited by Guarantee': {
+            en: 'Company - Limited by Guarantee',
+            cy: 'Cwmni - Cyfyngedig trwy Warant'
         },
-        "Company - Listed Publicly": {
-            "en": "Company - Listed Publicly",
-            "cy": "Cwmni - Wedi'i Restru'n Gyhoeddus"
+        'Company - Listed Publicly': {
+            en: 'Company - Listed Publicly',
+            cy: "Cwmni - Wedi'i Restru'n Gyhoeddus"
         },
-        "Credit Union": {
-            "en": "Credit Union",
-            "cy": "Undeb Credyd"
+        'Credit Union': {
+            en: 'Credit Union',
+            cy: 'Undeb Credyd'
         },
-        "Friendly Society": {
-            "en": "Friendly Society",
-            "cy": "Cymdeithas Gyfeillgar"
+        'Friendly Society': {
+            en: 'Friendly Society',
+            cy: 'Cymdeithas Gyfeillgar'
         },
-        "Industrial & Provident Society": {
-            "en": "Industrial & Provident Society",
-            "cy": "Cymdeithas Ddiwydiannol a Darbodus"
+        'Industrial & Provident Society': {
+            en: 'Industrial & Provident Society',
+            cy: 'Cymdeithas Ddiwydiannol a Darbodus'
         },
-        "Limited Liability Partnership": {
-            "en": "Limited Liability Partnership",
-            "cy": "Partneriaeth Atebolrwydd Cyfyngedig"
+        'Limited Liability Partnership': {
+            en: 'Limited Liability Partnership',
+            cy: 'Partneriaeth Atebolrwydd Cyfyngedig'
         },
-        "Other": {
-            "en": "Other",
-            "cy": "Arall"
+        Other: {
+            en: 'Other',
+            cy: 'Arall'
         },
-        "Other: All": {
-            "en": "Other: All",
-            "cy": "Arall: Pob un"
+        'Other: All': {
+            en: 'Other: All',
+            cy: 'Arall: Pob un'
         },
-        "Church-based faith organisation": {
-            "en": "Church-based faith organisation",
-            "cy": "Mudiad ffydd seiliedig mewn eglwys"
+        'Church-based faith organisation': {
+            en: 'Church-based faith organisation',
+            cy: 'Mudiad ffydd seiliedig mewn eglwys'
         },
-        "Further / Higher Education": {
-            "en": "Further / Higher Education",
-            "cy": "Addysg Bellach / Uwch"
+        'Further / Higher Education': {
+            en: 'Further / Higher Education',
+            cy: 'Addysg Bellach / Uwch'
         },
-        "Independent School": {
-            "en": "Independent School",
-            "cy": "Ysgol Annibynnol"
+        'Independent School': {
+            en: 'Independent School',
+            cy: 'Ysgol Annibynnol'
         },
-        "Individual": {
-            "en": "Individual",
-            "cy": "Unigolyn"
+        Individual: {
+            en: 'Individual',
+            cy: 'Unigolyn'
         },
-        "Non charitable unincorporated organisation": {
-            "en": "Non charitable unincorporated organisation",
-            "cy": "Mudiad anelusennol anghorfforedig"
+        'Non charitable unincorporated organisation': {
+            en: 'Non charitable unincorporated organisation',
+            cy: 'Mudiad anelusennol anghorfforedig'
         },
-        "Parochial Church Council": {
-            "en": "Parochial Church Council",
-            "cy": "Cyngor Eglwys Blwyfol"
+        'Parochial Church Council': {
+            en: 'Parochial Church Council',
+            cy: 'Cyngor Eglwys Blwyfol'
         },
-        "Partnership": {
-            "en": "Partnership",
-            "cy": "Partneriaeth"
+        Partnership: {
+            en: 'Partnership',
+            cy: 'Partneriaeth'
         },
-        "Sole Trader": {
-            "en": "Sole Trader",
-            "cy": "Unig Fasnachwr"
+        'Sole Trader': {
+            en: 'Sole Trader',
+            cy: 'Unig Fasnachwr'
         },
-        "University": {
-            "en": "University",
-            "cy": "Prifysgol"
+        University: {
+            en: 'University',
+            cy: 'Prifysgol'
         },
-        "Public Sector": {
-            "en": "Public Sector",
-            "cy": "Sector Cyhoeddus"
+        'Public Sector': {
+            en: 'Public Sector',
+            cy: 'Sector Cyhoeddus'
         },
-        "Public Sector: All": {
-            "en": "Public Sector: All",
-            "cy": "Sector Cyhoeddus: Pob un"
+        'Public Sector: All': {
+            en: 'Public Sector: All',
+            cy: 'Sector Cyhoeddus: Pob un'
         },
-        "Non-Departmental Public Body": {
-            "en": "Non-Departmental Public Body",
-            "cy": "Corff Cyhoeddus Anadrannol"
+        'Non-Departmental Public Body': {
+            en: 'Non-Departmental Public Body',
+            cy: 'Corff Cyhoeddus Anadrannol'
         },
-        "Community Council": {
-            "en": "Community Council",
-            "cy": "Cyngor Cymuned"
+        'Community Council': {
+            en: 'Community Council',
+            cy: 'Cyngor Cymuned'
         },
-        "Fire Service": {
-            "en": "Fire Service",
-            "cy": "Gwasanaeth Tân"
+        'Fire Service': {
+            en: 'Fire Service',
+            cy: 'Gwasanaeth Tân'
         },
-        "Health Authority": {
-            "en": "Health Authority",
-            "cy": "Awdurdod Iechyd"
+        'Health Authority': {
+            en: 'Health Authority',
+            cy: 'Awdurdod Iechyd'
         },
-        "Local Authority": {
-            "en": "Local Authority",
-            "cy": "Awdurdod Lleol"
+        'Local Authority': {
+            en: 'Local Authority',
+            cy: 'Awdurdod Lleol'
         },
-        "NHS Trust - Foundation": {
-            "en": "NHS Trust - Foundation",
-            "cy": "Ymddiriedolaeth GIG - Sefydledig"
+        'NHS Trust - Foundation': {
+            en: 'NHS Trust - Foundation',
+            cy: 'Ymddiriedolaeth GIG - Sefydledig'
         },
-        "NHS Trust - Non Foundation": {
-            "en": "NHS Trust - Non Foundation",
-            "cy": "Ymddiriedolaeth GIG - Ansefydledig"
+        'NHS Trust - Non Foundation': {
+            en: 'NHS Trust - Non Foundation',
+            cy: 'Ymddiriedolaeth GIG - Ansefydledig'
         },
-        "Parish Council": {
-            "en": "Parish Council",
-            "cy": "Cyngor Plwyf"
+        'Parish Council': {
+            en: 'Parish Council',
+            cy: 'Cyngor Plwyf'
         },
-        "Police Authority": {
-            "en": "Police Authority",
-            "cy": "Awdurdod Heddlu"
+        'Police Authority': {
+            en: 'Police Authority',
+            cy: 'Awdurdod Heddlu'
         },
-        "Prison Service": {
-            "en": "Prison Service",
-            "cy": "Gwasanaeth Carchar"
+        'Prison Service': {
+            en: 'Prison Service',
+            cy: 'Gwasanaeth Carchar'
         },
-        "Town Council": {
-            "en": "Town Council",
-            "cy": "Cyngor Tref"
+        'Town Council': {
+            en: 'Town Council',
+            cy: 'Cyngor Tref'
         },
-        "School": {
-            "en": "School",
-            "cy": "Ysgol"
+        School: {
+            en: 'School',
+            cy: 'Ysgol'
         },
-        "School: All": {
-            "en": "School: All",
-            "cy": "Ysgol: Pob un"
+        'School: All': {
+            en: 'School: All',
+            cy: 'Ysgol: Pob un'
         },
-        "Academy": {
-            "en": "Academy",
-            "cy": "Academi"
+        Academy: {
+            en: 'Academy',
+            cy: 'Academi'
         },
-        "City Technology College": {
-            "en": "City Technology College",
-            "cy": "Coleg Technoleg Dinas"
+        'City Technology College': {
+            en: 'City Technology College',
+            cy: 'Coleg Technoleg Dinas'
         },
-        "Community School": {
-            "en": "Community School",
-            "cy": "Ysgol Gymunedol"
+        'Community School': {
+            en: 'Community School',
+            cy: 'Ysgol Gymunedol'
         },
-        "Foundation or Trust School": {
-            "en": "Foundation or Trust School",
-            "cy": "Ysgol Sefydledig neu Ymddiriedolaeth"
+        'Foundation or Trust School': {
+            en: 'Foundation or Trust School',
+            cy: 'Ysgol Sefydledig neu Ymddiriedolaeth'
         },
-        "State School": {
-            "en": "State School",
-            "cy": "Ysgol Wladol"
+        'State School': {
+            en: 'State School',
+            cy: 'Ysgol Wladol'
         },
-        "Voluntary Aided School": {
-            "en": "Voluntary Aided School",
-            "cy": "Ysgol Wirfoddol a Gynorthwyir"
+        'Voluntary Aided School': {
+            en: 'Voluntary Aided School',
+            cy: 'Ysgol Wirfoddol a Gynorthwyir'
         },
-        "Voluntary Controlled School": {
-            "en": "Voluntary Controlled School",
-            "cy": "Ysgol Wirfoddol a Reolir"
+        'Voluntary Controlled School': {
+            en: 'Voluntary Controlled School',
+            cy: 'Ysgol Wirfoddol a Reolir'
         }
     }
 };
 
-const getTranslation = (langKey, str, locale) => get(translations, [langKey, str, locale], str);
+const getTranslation = (langKey, str, locale) =>
+    get(translations, [langKey, str, locale], str);
 
 /**
  * Utility function to add in a translation to the label


### PR DESCRIPTION
Noticed that the main remaining thing that googlebot is working its way through is the location links from grant pages. This PR optimises that query.

This is a fairly specific change though so we may want to revisit this. Adds a $project step if the query is only a location query to encourage it to use a better index. Seems backed up by this https://jira.mongodb.org/browse/SERVER-7568?focusedCommentId=814169&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-814169

Feels a bit too magic to me but I've confirmed that it makes a noticable difference.