### PR TITLE
Lock event-stream version to 3.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "csv-parser": "1.12.1",
     "eslint": "5.7.0",
     "eslint-plugin-node": "7.0.1",
-    "event-stream": "^3.3.4",
+    "event-stream": "3.3.4",
     "jest": "23.6.0",
     "jest-environment-node": "^23.4.0",
     "mongodb-memory-server": "2.4.3",


### PR DESCRIPTION
Locks event stream version. Our lock file was already on `3.3.4` but the range in package.json theoretically allows this to be updated if we ran an install. Explicitly locking to `3.3.4`.

You can run `npm ls event-stream flatmap-stream` to confirm that flatmap-stream should not be listed.