### PR TITLE
Data cleanup

### DIFF
--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -47,12 +47,14 @@ const parseDates = data => {
     ];
     dateFields.forEach(dateField => {
         if (data[dateField]) {
-            // We can't specify a format here because the source data uses different formats
-            // eg. older data is 2004-04-16 and some of it uses 8/17/15
-            let d = moment(data[dateField].trim());
-            data[dateField] = {
-                $date: d.toDate()
-            };
+            // We specify several parsing formats here because the source data uses different formats
+            // eg. older data is 2004-04-16 and the rest uses 8/17/15
+            const parsedDate = moment(data[dateField].trim(), ["MM/DD/YYYY", "YYYY-MM-DD"]);
+            if (parsedDate.isValid()) {
+                data[dateField] = {
+                    $date: parsedDate.toDate()
+                };
+            }
         }
     });
     return data;

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -174,11 +174,15 @@ const fixHeroesReturnTypo = data => {
 };
 
 // Rename funding programmes from their FMS/internal name
-// to a public-facing one
+// to a public-facing one, or fix a typo / case inconsistency
 const programmesToRename = [
     {
         from: 'UK Accelerating Ideas',
         to: 'UK Portfolio'
+    },
+    {
+        from: 'Fulfilling lives: HeadStart',
+        to: 'Fulfilling Lives: HeadStart'
     }
 ];
 const renameProgrammes = data => {


### PR DESCRIPTION
Mark Waterhouse pointed out this error:

![image](https://user-images.githubusercontent.com/394376/49436633-7b050a00-f7b1-11e8-9b3e-ac0d1ef06a05.png)

This change renames the second one to match the first – I couldn't think of a reliable way of automating this and I checked the entire list to see if this has happened in any other cases (it hasn't), so a manual rename seemed simplest.

It also silences a `moment` parser warning as I realised we can specify multiple date formats to attempt to parse a string with, rather than just one.

Once this is approved I can "deploy" the new data, which will merge those duplicate programmes.