### PR TITLE
Use the new slugs for all the migrated legacy funding programmes

### DIFF
--- a/data/fundingProgrammes.js
+++ b/data/fundingProgrammes.js
@@ -3,52 +3,52 @@ module.exports = {
     "CWG1": {
         "_id": "2014 Communities",
         "code": "CWG1",
-        "urlPath": "/global-content/programmes/scotland/2014-communities"
+        "urlPath": "2014-communities"
     },
     "SAV1": {
         "_id": "Active Futures",
         "code": "SAV1",
-        "urlPath": "/global-content/programmes/scotland/active-futures"
+        "urlPath": "active-futures"
     },
     "ALS1": {
         "_id": "Active Lifestyles",
         "code": "ALS1",
-        "urlPath": "/global-content/programmes/northern-ireland/active-lifestyles"
+        "urlPath": "active-lifestyles"
     },
     "WAY1": {
         "_id": "Activities for Young People",
         "code": "WAY1",
-        "urlPath": "/global-content/programmes/uk-wide/positive-activities-for-young-people"
+        "urlPath": "positive-activities-for-young-people"
     },
     "AGE1": {
         "_id": "AdvantAGE",
         "code": "AGE1",
-        "urlPath": "/global-content/programmes/wales/advantage"
+        "urlPath": "advantage"
     },
     "AP1": {
         "_id": "Advice Plus",
         "code": "AP1",
-        "urlPath": "/global-content/programmes/england/advice-plus"
+        "urlPath": "advice-plus"
     },
     "AP2": {
         "_id": "Advice Plus",
         "code": "AP2",
-        "urlPath": "/global-content/programmes/england/advice-plus"
+        "urlPath": "advice-plus"
     },
     "AST1": {
         "_id": "Advice Services Transition Fund",
         "code": "AST1",
-        "urlPath": "/global-content/programmes/england/advice-services-transition-fund"
+        "urlPath": "advice-services-transition-fund"
     },
     "AB1": {
         "_id": "Ageing Better",
         "code": "AB1",
-        "urlPath": "/global-content/programmes/england/fulfilling-lives-ageing-better"
+        "urlPath": "fulfilling-lives-ageing-better"
     },
     "ABD1": {
         "_id": "Ageing Better - Partnership Funding",
         "code": "ABD1",
-        "urlPath": "/global-content/programmes/england/fulfilling-lives-ageing-better"
+        "urlPath": "fulfilling-lives-ageing-better"
     },
     "ARR1": {
         "_id": "Arrangements",
@@ -112,17 +112,17 @@ module.exports = {
     "AANI2": {
         "_id": "Awards for All Northern Ireland",
         "code": "AANI2",
-        "urlPath": "/global-content/programmes/northern-ireland/awards-for-all-northern-ireland"
+        "urlPath": "awards-for-all-northern-ireland"
     },
     "AANI3": {
         "_id": "Awards for All Northern Ireland",
         "code": "AANI3",
-        "urlPath": "/global-content/programmes/northern-ireland/awards-for-all-northern-ireland"
+        "urlPath": "awards-for-all-northern-ireland"
     },
     "AANI4": {
         "_id": "Awards for All Northern Ireland",
         "code": "AANI4",
-        "urlPath": "/global-content/programmes/northern-ireland/awards-for-all-northern-ireland"
+        "urlPath": "awards-for-all-northern-ireland"
     },
     "AFS2": {
         "_id": "Awards for All Scotland",
@@ -132,22 +132,22 @@ module.exports = {
     "BAS1": {
         "_id": "BASIS",
         "code": "BAS1",
-        "urlPath": "/global-content/programmes/england/basis"
+        "urlPath": "basis"
     },
     "BAS3": {
         "_id": "BASIS",
         "code": "BAS3",
-        "urlPath": "/global-content/programmes/england/basis"
+        "urlPath": "basis"
     },
     "BI1": {
         "_id": "BIG Innovation",
         "code": "BI1",
-        "urlPath": "/global-content/programmes/wales/big-innovation"
+        "urlPath": "big-innovation"
     },
     "BLT1": {
         "_id": "Big Local Trust: Getting people involved",
         "code": "BLT1",
-        "urlPath": "/global-content/programmes/england/big-local"
+        "urlPath": "big-local"
     },
     "BRE1": {
         "_id": "Breathing Places",
@@ -164,7 +164,7 @@ module.exports = {
     "BF1": {
         "_id": "Bright New Futures",
         "code": "BF1",
-        "urlPath": "/global-content/programmes/wales/bright-new-futures"
+        "urlPath": "bright-new-futures"
     },
     "EUD1": {
         "_id": "Building Better Opportunities",
@@ -189,62 +189,62 @@ module.exports = {
     "CE2": {
         "_id": "Building Quality Childcare",
         "code": "CE2",
-        "urlPath": "/global-content/programmes/northern-ireland/building-quality-childcare"
+        "urlPath": "building-quality-childcare"
     },
     "BCT1": {
         "_id": "Buildings Change Trust",
         "code": "BCT1",
-        "urlPath": "/global-content/programmes/northern-ireland/building-change-trust"
+        "urlPath": "building-change-trust"
     },
     "CLB1": {
         "_id": "Celebrate",
         "code": "CLB1",
-        "urlPath": "/global-content/programmes/england/celebratefund"
+        "urlPath": "celebratefund"
     },
     "CEL1": {
         "_id": "Celebrate",
         "code": "CEL1",
-        "urlPath": "/global-content/programmes/england/celebratefund"
+        "urlPath": "celebratefund"
     },
     "CSP1": {
         "_id": "Changing Spaces",
         "code": "CSP1",
-        "urlPath": "/global-content/programmes/england/changing-spaces"
+        "urlPath": "changing-spaces"
     },
     "CSAP1": {
         "_id": "Changing Spaces",
         "code": "CSAP1",
-        "urlPath": "/global-content/programmes/england/changing-spaces"
+        "urlPath": "changing-spaces"
     },
     "WCP1": {
         "_id": "Child's Play Programme",
         "code": "WCP1",
-        "urlPath": "/global-content/programmes/wales/healthy-families-childs-play"
+        "urlPath": "healthy-families-childs-play"
     },
     "CX1": {
         "_id": "Childcare",
         "code": "CX1",
-        "urlPath": "/global-content/programmes/uk-wide/out-of-school-hours-childcare"
+        "urlPath": "out-of-school-hours-childcare"
     },
     "CT1": {
         "_id": "Childcare",
         "code": "CT1",
-        "urlPath": "/global-content/programmes/uk-wide/out-of-school-hours-childcare"
+        "urlPath": "out-of-school-hours-childcare"
     },
     "CPP1": {
         "_id": "Children's Play",
         "code": "CPP1",
-        "urlPath": "/global-content/programmes/england/childrens-play"
+        "urlPath": "childrens-play"
     },
     "CP1": {
         "_id": "Childrens Play",
         "code": "CP1",
-        "urlPath": "/global-content/programmes/england/childrens-play"
+        "urlPath": "childrens-play"
     },
     "PL1": {
         "_id": "Childrens Play: Playful Ideas",
         "code": "PL1",
-        "urlPath": "/global-content/programmes/england/childrens-play"
+        "urlPath": "childrens-play"
     },
     "ENC1": {
         "_id": "Collaboration",
@@ -253,92 +253,92 @@ module.exports = {
     "SRC1": {
         "_id": "Communities Living Sustainably",
         "code": "SRC1",
-        "urlPath": "/global-content/programmes/england/communities-living-sustainably"
+        "urlPath": "communities-living-sustainably"
     },
     "CFF1": {
         "_id": "Communities and Families Fund",
         "code": "CFF1",
-        "urlPath": "/global-content/programmes/scotland/communities-and-families-fund"
+        "urlPath": "communities-and-families-fund"
     },
     "ECL1": {
         "_id": "Community Access to Lifelong Learning",
         "code": "ECL1",
-        "urlPath": "/global-content/programmes/uk-wide/community-access-to-lifelong-learning"
+        "urlPath": "community-access-to-lifelong-learning"
     },
     "CAT1": {
         "_id": "Community Asset Transfer",
         "code": "CAT1",
-        "urlPath": "/global-content/programmes/wales/community-asset-transfer-2"
+        "urlPath": "community-asset-transfer-2"
     },
     "CAT4": {
         "_id": "Community Asset Transfer 2",
         "code": "CAT4",
-        "urlPath": "/global-content/programmes/wales/community-asset-transfer-2"
+        "urlPath": "community-asset-transfer-2"
     },
     "CAT2": {
         "_id": "Community Asset Transfer Round 2",
         "code": "CAT2",
-        "urlPath": "/global-content/programmes/wales/community-asset-transfer-2"
+        "urlPath": "community-asset-transfer-2"
     },
     "SCA1": {
         "_id": "Community Assets",
         "code": "SCA1",
-        "urlPath": "/global-content/programmes/scotland/community-assets"
+        "urlPath": "community-assets"
     },
     "CBS1": {
         "_id": "Community Buildings",
         "code": "CBS1",
-        "urlPath": "/global-content/programmes/england/community-buildings"
+        "urlPath": "community-buildings"
     },
     "BPL1": {
         "_id": "Community Buildings Trial Programme",
         "code": "BPL1",
-        "urlPath": "/global-content/programmes/england/community-buildings"
+        "urlPath": "community-buildings"
     },
     "CL1": {
         "_id": "Community Libraries",
         "code": "CL1",
-        "urlPath": "/global-content/programmes/england/community-libraries"
+        "urlPath": "community-libraries"
     },
     "NAC1": {
         "_id": "Community Sport (Active Lifestyles)",
         "code": "NAC1",
-        "urlPath": "/global-content/programmes/northern-ireland/active-lifestyles"
+        "urlPath": "active-lifestyles"
     },
     "NSC1": {
         "_id": "Community Sport - SCNI",
         "code": "NSC1",
-        "urlPath": "/global-content/programmes/northern-ireland/active-lifestyles"
+        "urlPath": "active-lifestyles"
     },
     "CVC1": {
         "_id": "Community Voice",
         "code": "CVC1",
-        "urlPath": "/global-content/programmes/wales/community-voice"
+        "urlPath": "community-voice"
     },
     "CWL1": {
         "_id": "Community Wildlife",
         "code": "CWL1",
-        "urlPath": "/global-content/programmes/england/community-wildlife"
+        "urlPath": "community-wildlife"
     },
     "CN1": {
         "_id": "Complex Needs",
         "code": "CN1",
-        "urlPath": "/global-content/programmes/england/multiple-and-complex-needs"
+        "urlPath": "multiple-and-complex-needs"
     },
     "SCS3": {
         "_id": "Coronary Heart Disease/Stroke/Cancer",
         "code": "SCS3",
-        "urlPath": "/global-content/programmes/northern-ireland/coronary-heart-disease-stroke-cancer-ni"
+        "urlPath": "coronary-heart-disease-stroke-cancer-ni"
     },
     "CYS1": {
         "_id": "Create Your Space",
         "code": "CYS1",
-        "urlPath": "/global-content/programmes/wales/create-your-space"
+        "urlPath": "create-your-space"
     },
     "CFA1": {
         "_id": "Culture for All",
         "code": "CFA1",
-        "urlPath": "/global-content/programmes/northern-ireland/culture-for-all-northern-ireland"
+        "urlPath": "culture-for-all-northern-ireland"
     },
     "DE1": {
         "_id": "Delegation pilot programme",
@@ -347,37 +347,37 @@ module.exports = {
     "EDE1": {
         "_id": "Diagnostic Equipment",
         "code": "EDE1",
-        "urlPath": "/global-content/programmes/uk-wide/new-opportunities-for-health-diagnostic-equipment"
+        "urlPath": "new-opportunities-for-health-diagnostic-equipment"
     },
     "UDI2": {
         "_id": "Digitisation",
         "code": "UDI2",
-        "urlPath": "/global-content/programmes/uk-wide/digitisation"
+        "urlPath": "digitisation"
     },
     "SEA1": {
         "_id": "Early Action Scotland",
         "code": "SEA1",
-        "urlPath": "/global-content/programmes/scotland/early-action-system-change"
+        "urlPath": "early-action-system-change"
     },
     "EYP2": {
         "_id": "Empowering Young People",
         "code": "EYP2",
-        "urlPath": "/global-content/programmes/northern-ireland/empowering-young-people"
+        "urlPath": "empowering-young-people"
     },
     "EYP3": {
         "_id": "Empowering Young People",
         "code": "EYP3",
-        "urlPath": "/global-content/programmes/northern-ireland/empowering-young-people"
+        "urlPath": "empowering-young-people"
     },
     "EVL1": {
         "_id": "Energy Efficient Venues (Large)",
         "code": "EVL1",
-        "urlPath": "/global-content/programmes/northern-ireland/energy-efficient-venues"
+        "urlPath": "energy-efficient-venues"
     },
     "EVS1": {
         "_id": "Energy Efficient Venues (Small)",
         "code": "EVS1",
-        "urlPath": "/global-content/programmes/northern-ireland/energy-efficient-venues"
+        "urlPath": "energy-efficient-venues"
     },
     "EEX1": {
         "_id": "Extended Schools",
@@ -386,7 +386,7 @@ module.exports = {
     "FL1": {
         "_id": "Family Learning",
         "code": "FL1",
-        "urlPath": "/global-content/programmes/england/family-learning"
+        "urlPath": "family-learning"
     },
     "F4F1": {
         "_id": "Fifteenth Anniversary Awards",
@@ -395,22 +395,22 @@ module.exports = {
     "ABS1": {
         "_id": "Fulfilling Lives: A Better Start",
         "code": "ABS1",
-        "urlPath": "/global-content/programmes/england/fulfilling-lives-headstart"
+        "urlPath": "fulfilling-lives-headstart"
     },
     "HST3": {
         "_id": "Fulfilling Lives: HeadStart",
         "code": "HST3",
-        "urlPath": "/global-content/programmes/england/fulfilling-lives-headstart"
+        "urlPath": "fulfilling-lives-headstart"
     },
     "HST1": {
         "_id": "Fulfilling lives: HeadStart",
         "code": "HST1",
-        "urlPath": "/global-content/programmes/england/fulfilling-lives-headstart"
+        "urlPath": "fulfilling-lives-headstart"
     },
     "MM1": {
         "_id": "GM04",
         "code": "MM1",
-        "urlPath": "/global-content/programmes/scotland/gm04"
+        "urlPath": "gm04"
     },
     "EGE1": {
         "_id": "Get REAL",
@@ -423,47 +423,47 @@ module.exports = {
     "GC1": {
         "_id": "Growing Community Assets",
         "code": "GC1",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "GCP1": {
         "_id": "Growing Community Assets",
         "code": "GCP1",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "EHL1": {
         "_id": "Healthy Living Centres",
         "code": "EHL1",
-        "urlPath": "/global-content/programmes/uk-wide/healthy-living-centres"
+        "urlPath": "healthy-living-centres"
     },
     "NIH1": {
         "_id": "Healthy Minds NI",
         "code": "NIH1",
-        "urlPath": "/global-content/programmes/northern-ireland/healthy-minds-northern-ireland"
+        "urlPath": "healthy-minds-northern-ireland"
     },
     "HTC1": {
         "_id": "Help Through Crisis",
         "code": "HTC1",
-        "urlPath": "/global-content/programmes/england/help-through-crisis"
+        "urlPath": "help-through-crisis"
     },
     "AVR1": {
         "_id": "Heroes Return",
         "code": "AVR1",
-        "urlPath": "/global-content/programmes/uk-wide/heroes-return"
+        "urlPath": "heroes-return"
     },
     "UVH1": {
         "_id": "Heroes Return",
         "code": "UVH1",
-        "urlPath": "/global-content/programmes/uk-wide/heroes-return"
+        "urlPath": "heroes-return"
     },
     "UVH2": {
         "_id": "Home Front Recall",
         "code": "UVH2",
-        "urlPath": "/global-content/programmes/uk-wide/home-front-recall"
+        "urlPath": "home-front-recall"
     },
     "AHF1": {
         "_id": "Home Front Recall",
         "code": "AHF1",
-        "urlPath": "/global-content/programmes/uk-wide/home-front-recall"
+        "urlPath": "home-front-recall"
     },
     "HHP1": {
         "_id": "Hothouse Small Grants",
@@ -476,162 +476,162 @@ module.exports = {
     "ARP1": {
         "_id": "Impact of Alcohol",
         "code": "ARP1",
-        "urlPath": "/global-content/programmes/northern-ireland/impact-of-alcohol"
+        "urlPath": "impact-of-alcohol"
     },
     "ARD1": {
         "_id": "Impact of Alcohol NI Wide",
         "code": "ARD1",
-        "urlPath": "/global-content/programmes/northern-ireland/impact-of-alcohol"
+        "urlPath": "impact-of-alcohol"
     },
     "NIB1": {
         "_id": "Improving Community Buildings",
         "code": "NIB1",
-        "urlPath": "/global-content/programmes/northern-ireland/improving-community-buildings"
+        "urlPath": "improving-community-buildings"
     },
     "IFC1": {
         "_id": "Improving Financial Confidence",
         "code": "IFC1",
-        "urlPath": "/global-content/programmes/england/improving-financial-confidence"
+        "urlPath": "improving-financial-confidence"
     },
     "IMP1": {
         "_id": "Improving Futures",
         "code": "IMP1",
-        "urlPath": "/global-content/programmes/uk-wide/improving-futures"
+        "urlPath": "improving-futures"
     },
     "CE3": {
         "_id": "Integrated Children's Centres Wales",
         "code": "CE3",
-        "urlPath": "/global-content/programmes/wales/integrated-childrens-centres"
+        "urlPath": "integrated-childrens-centres"
     },
     "INT1": {
         "_id": "International",
         "code": "INT1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "ICA2": {
         "_id": "International Communities",
         "code": "ICA2",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "IG1": {
         "_id": "International Grants",
         "code": "IG1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "ICA1": {
         "_id": "International Grants",
         "code": "ICA1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "ISM1": {
         "_id": "International Grants",
         "code": "ISM1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "IS1": {
         "_id": "International Grants",
         "code": "IS1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "ICP1": {
         "_id": "International Grants",
         "code": "ICP1",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "IS3": {
         "_id": "International Grants",
         "code": "IS3",
-        "urlPath": "/global-content/programmes/uk-wide/international-communities"
+        "urlPath": "international-strategic"
     },
     "SV1TFL": {
         "_id": "Investing in Communities",
         "code": "SV1TFL",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "SV1DIC": {
         "_id": "Investing in Communities",
         "code": "SV1DIC",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "SV1LT": {
         "_id": "Investing in Communities",
         "code": "SV1LT",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "SI1LT": {
         "_id": "Investing in Communities",
         "code": "SI1LT",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "SI1TFL": {
         "_id": "Investing in Communities",
         "code": "SI1TFL",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "SI1DIC": {
         "_id": "Investing in Communities",
         "code": "SI1DIC",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "PT1": {
         "_id": "Investing in Communities",
         "code": "PT1",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2LTDEV": {
         "_id": "Investing in Communities",
         "code": "IIC2LTDEV",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2GCA": {
         "_id": "Investing in Communities",
         "code": "IIC2GCA",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2TFL": {
         "_id": "Investing in Communities",
         "code": "IIC2TFL",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2LT": {
         "_id": "Investing in Communities",
         "code": "IIC2LT",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2TFLDEV": {
         "_id": "Investing in Communities",
         "code": "IIC2TFLDEV",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2CC": {
         "_id": "Investing in Communities",
         "code": "IIC2CC",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "IIC2GCADEV": {
         "_id": "Investing in Communities",
         "code": "IIC2GCADEV",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "CS1": {
         "_id": "Investing in Communities",
         "code": "CS1",
-        "urlPath": "/global-content/programmes/scotland/investing-in-communities-growing-community-assets"
+        "urlPath": "investing-in-communities-growing-community-assets"
     },
     "INV1": {
         "_id": "Investing in Ideas",
         "code": "INV1",
-        "urlPath": "/global-content/programmes/scotland/investing-in-ideas"
+        "urlPath": "investing-in-ideas"
     },
     "INV2": {
         "_id": "Investing in Ideas",
         "code": "INV2",
-        "urlPath": "/global-content/programmes/scotland/investing-in-ideas"
+        "urlPath": "investing-in-ideas"
     },
     "PM7": {
         "_id": "Jubilee People's Millions",
         "code": "PM7",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "SLG1": {
         "_id": "Large Grants Scotland",
@@ -644,22 +644,22 @@ module.exports = {
     "ARR2": {
         "_id": "Life Skills",
         "code": "ARR2",
-        "urlPath": "/global-content/programmes/wales/life-skills-project"
+        "urlPath": "life-skills-project"
     },
     "NLL1": {
         "_id": "Live and Learn",
         "code": "NLL1",
-        "urlPath": "/global-content/programmes/northern-ireland/live-and-learn"
+        "urlPath": "live-and-learn"
     },
     "LL1": {
         "_id": "Living Landmarks",
         "code": "LL1",
-        "urlPath": "/global-content/programmes/uk-wide/living-landmarks"
+        "urlPath": "living-landmarks"
     },
     "YPS1": {
         "_id": "Make it Happen",
         "code": "YPS1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-make-it-happen"
+        "urlPath": "young-peoples-fund-make-it-happen"
     },
     "SMG1": {
         "_id": "Medium Grants Scotland",
@@ -672,12 +672,12 @@ module.exports = {
     "MHM1": {
         "_id": "Mental Health Matters",
         "code": "MHM1",
-        "urlPath": "/global-content/programmes/wales/mental-health-matters"
+        "urlPath": "mental-health-matters"
     },
     "WMA1": {
         "_id": "Mentro Allan",
         "code": "WMA1",
-        "urlPath": "/global-content/programmes/wales/mentro-allan"
+        "urlPath": "mentro-allan"
     },
     "LGE1": {
         "_id": "Micro Grants",
@@ -694,17 +694,17 @@ module.exports = {
     "MCM1": {
         "_id": "Millennium Commission",
         "code": "MCM1",
-        "urlPath": "/global-content/programmes/uk-wide/millennium-now"
+        "urlPath": "millennium-now"
     },
     "NOW1": {
         "_id": "Millennium Now",
         "code": "NOW1",
-        "urlPath": "/global-content/programmes/uk-wide/millennium-now"
+        "urlPath": "millennium-now"
     },
     "MND1": {
         "_id": "Multiple Needs - Partnership Funding",
         "code": "MND1",
-        "urlPath": "/global-content/programmes/england/multiple-and-complex-needs"
+        "urlPath": "multiple-and-complex-needs"
     },
     "SAC1": {
         "_id": "NOPES Activities Programme Scotland",
@@ -728,32 +728,32 @@ module.exports = {
     "NPE1": {
         "_id": "New Opportunities for PE and Sport",
         "code": "NPE1",
-        "urlPath": "/global-content/programmes/uk-wide/new-opportunities-for-pe-and-sport"
+        "urlPath": "new-opportunities-for-pe-and-sport"
     },
     "EPE1": {
         "_id": "New Opportunities for PE and Sport",
         "code": "EPE1",
-        "urlPath": "/global-content/programmes/uk-wide/new-opportunities-for-pe-and-sport"
+        "urlPath": "new-opportunities-for-pe-and-sport"
     },
     "WPE1": {
         "_id": "New Opportunities for PE and Sport",
         "code": "WPE1",
-        "urlPath": "/global-content/programmes/uk-wide/new-opportunities-for-pe-and-sport"
+        "urlPath": "new-opportunities-for-pe-and-sport"
     },
     "SPE1": {
         "_id": "New Opportunities for PE and Sport",
         "code": "SPE1",
-        "urlPath": "/global-content/programmes/uk-wide/new-opportunities-for-pe-and-sport"
+        "urlPath": "new-opportunities-for-pe-and-sport"
     },
     "CE4": {
         "_id": "New Opportunities for Quality Childcare",
         "code": "CE4",
-        "urlPath": "/global-content/programmes/scotland/new-opportunities-for-quality-childcare"
+        "urlPath": "new-opportunities-for-quality-childcare"
     },
     "SIE1": {
         "_id": "Next Steps",
         "code": "SIE1",
-        "urlPath": "/global-content/programmes/england/next-steps"
+        "urlPath": "next-steps"
     },
     "EOO1": {
         "_id": "OSHL School Sport Co-ordinator",
@@ -770,32 +770,32 @@ module.exports = {
     "OP1": {
         "_id": "Our Place",
         "code": "OP1",
-        "urlPath": "/global-content/programmes/scotland/our-place"
+        "urlPath": "our-place"
     },
     "CA2": {
         "_id": "Out of School Hours Childcare",
         "code": "CA2",
-        "urlPath": "/global-content/programmes/uk-wide/out-of-school-hours-childcare"
+        "urlPath": "out-of-school-hours-childcare"
     },
     "CB2": {
         "_id": "Out of School Hours Childcare",
         "code": "CB2",
-        "urlPath": "/global-content/programmes/uk-wide/out-of-school-hours-childcare"
+        "urlPath": "out-of-school-hours-childcare"
     },
     "EPC1": {
         "_id": "Palliative Care",
         "code": "EPC1",
-        "urlPath": "/england/global-content/programmes/england/palliative-care-for-adults"
+        "urlPath": "/englandpalliative-care-for-adults"
     },
     "WPC1": {
         "_id": "Palliative Care: Wales",
         "code": "WPC1",
-        "urlPath": "/global-content/programmes/wales/palliative-care-wales"
+        "urlPath": "palliative-care-wales"
     },
     "PFP1": {
         "_id": "Parks for People",
         "code": "PFP1",
-        "urlPath": "/global-content/programmes/england/parks-for-people"
+        "urlPath": "parks-for-people"
     },
     "PNE1": {
         "_id": "Partnerships",
@@ -810,7 +810,7 @@ module.exports = {
     "PAC1": {
         "_id": "People and Communities",
         "code": "PAC1",
-        "urlPath": "/global-content/programmes/northern-ireland/people-and-communities"
+        "urlPath": "people-and-communities"
     },
     "PPA1": {
         "_id": "People and Places",
@@ -904,22 +904,22 @@ module.exports = {
     "RCB1": {
         "_id": "Reaching Communities Buildings",
         "code": "RCB1",
-        "urlPath": "/global-content/programmes/england/reaching-communities-buildings-england"
+        "urlPath": "reaching-communities-buildings-england"
     },
     "RO1": {
         "_id": "Reaching Out - Connecting Older People",
         "code": "RO1",
-        "urlPath": "/global-content/programmes/northern-ireland/reaching-out-connecting-older-people"
+        "urlPath": "reaching-out-connecting-older-people"
     },
     "RY1": {
         "_id": "Reaching Out - Empowering Young People",
         "code": "RY1",
-        "urlPath": "/global-content/programmes/northern-ireland/reaching-out-empowering-young-people"
+        "urlPath": "reaching-out-empowering-young-people"
     },
     "RF1": {
         "_id": "Reaching Out: Supporting Families",
         "code": "RF1",
-        "urlPath": "/global-content/programmes/northern-ireland/reaching-out-supporting-families"
+        "urlPath": "reaching-out-supporting-families"
     },
     "RAP1": {
         "_id": "Realising Ambition Portfolio",
@@ -928,7 +928,7 @@ module.exports = {
     "URE1": {
         "_id": "Renewable Energy",
         "code": "URE1",
-        "urlPath": "/global-content/programmes/uk-wide/renewable-energy"
+        "urlPath": "renewable-energy"
     },
     "RG1": {
         "_id": "Research Grants",
@@ -949,7 +949,7 @@ module.exports = {
     "NSW1": {
         "_id": "Safe and Well",
         "code": "NSW1",
-        "urlPath": "/global-content/programmes/northern-ireland/safe-and-well"
+        "urlPath": "safe-and-well"
     },
     "SPP1": {
         "_id": "Scotland Portfolio Partner",
@@ -962,82 +962,82 @@ module.exports = {
     "NSP1": {
         "_id": "Space and Place",
         "code": "NSP1",
-        "urlPath": "/global-content/programmes/northern-ireland/space-and-place"
+        "urlPath": "space-and-place"
     },
     "SS1": {
         "_id": "Stepping Stones",
         "code": "SS1",
-        "urlPath": "/global-content/programmes/wales/stepping-stones"
+        "urlPath": "stepping-stones"
     },
     "TM1": {
         "_id": "Talent Match",
         "code": "TM1",
-        "urlPath": "/global-content/programmes/england/talent-match"
+        "urlPath": "talent-match"
     },
     "TMD1": {
         "_id": "Talent Match - Partnership Funding",
         "code": "TMD1",
-        "urlPath": "/global-content/programmes/england/talent-match"
+        "urlPath": "talent-match"
     },
     "PM1": {
         "_id": "The People's Millions",
         "code": "PM1",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "PM3": {
         "_id": "The People's Millions",
         "code": "PM3",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "PM6": {
         "_id": "The People's Millions",
         "code": "PM6",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "PM8": {
         "_id": "The People's Millions",
         "code": "PM8",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "PM9": {
         "_id": "The People's Millions",
         "code": "PM9",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-millions"
+        "urlPath": "the-peoples-millions"
     },
     "TPP1": {
         "_id": "The People's Projects",
         "code": "TPP1",
-        "urlPath": "/global-content/programmes/uk-wide/the-peoples-projects"
+        "urlPath": "the-peoples-projects"
     },
     "SLV1": {
         "_id": "The Silver Dreams Fund",
         "code": "SLV1",
-        "urlPath": "/global-content/programmes/england/the-siver-dreams-fund"
+        "urlPath": "the-siver-dreams-fund"
     },
     "NVT2": {
         "_id": "Their Past Your Future",
         "code": "NVT2",
-        "urlPath": "/global-content/programmes/uk-wide/their-past-your-future"
+        "urlPath": "their-past-your-future"
     },
     "EVT1": {
         "_id": "Their Past Your Future",
         "code": "EVT1",
-        "urlPath": "/global-content/programmes/uk-wide/their-past-your-future"
+        "urlPath": "their-past-your-future"
     },
     "NVT1": {
         "_id": "Their Past Your Future",
         "code": "NVT1",
-        "urlPath": "/global-content/programmes/uk-wide/their-past-your-future"
+        "urlPath": "their-past-your-future"
     },
     "SVT1": {
         "_id": "Their Past Your Future",
         "code": "SVT1",
-        "urlPath": "/global-content/programmes/uk-wide/their-past-your-future"
+        "urlPath": "their-past-your-future"
     },
     "WVT1": {
         "_id": "Their Past Your Future",
         "code": "WVT1",
-        "urlPath": "/global-content/programmes/uk-wide/their-past-your-future"
+        "urlPath": "their-past-your-future"
     },
     "TR1": {
         "_id": "Transfers of grants",
@@ -1046,7 +1046,7 @@ module.exports = {
     "WTS1": {
         "_id": "Transforming Your Space",
         "code": "WTS1",
-        "urlPath": "/global-content/programmes/northern-ireland/transforming-your-space-northern-ireland"
+        "urlPath": "transforming-your-space-northern-ireland"
     },
     "TRU1": {
         "_id": "Trusts",
@@ -1060,82 +1060,82 @@ module.exports = {
     "VLL1": {
         "_id": "Village SOS",
         "code": "VLL1",
-        "urlPath": "/global-content/programmes/uk-wide/village-sos"
+        "urlPath": "village-sos"
     },
     "VSA1": {
         "_id": "Village SOS Active",
         "code": "VSA1",
-        "urlPath": "/global-content/programmes/uk-wide/village-sos"
+        "urlPath": "village-sos"
     },
     "VSA2": {
         "_id": "Village SOS Active",
         "code": "VSA2",
-        "urlPath": "/global-content/programmes/uk-wide/village-sos"
+        "urlPath": "village-sos"
     },
     "WOL1": {
         "_id": "Way of Life Programme",
         "code": "WOL1",
-        "urlPath": "/global-content/programmes/northern-ireland/healthy-families-way-of-life"
+        "urlPath": "healthy-families-way-of-life"
     },
     "WB1": {
         "_id": "Well-being",
         "code": "WB1",
-        "urlPath": "/global-content/programmes/england/well-being"
+        "urlPath": "well-being"
     },
     "WGI1": {
         "_id": "Women and Girls Initiative",
         "code": "WGI1",
-        "urlPath": "/global-content/programmes/england/women-and-girls-initiative"
+        "urlPath": "women-and-girls-initiative"
     },
     "YPO1": {
         "_id": "YPF and Reaching Out - Grants to Orgs",
         "code": "YPO1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-reaching-out"
+        "urlPath": "young-peoples-fund-reaching-out"
     },
     "YPI1": {
         "_id": "Young Peoples Fund",
         "code": "YPI1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YSC1": {
         "_id": "Young Peoples Fund",
         "code": "YSC1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YPP1": {
         "_id": "Young Peoples Fund",
         "code": "YPP1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YPG1": {
         "_id": "Young Peoples Fund",
         "code": "YPG1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YPL1": {
         "_id": "Young Peoples Fund",
         "code": "YPL1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YIF1": {
         "_id": "Young Peoples Fund",
         "code": "YIF1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YPN1": {
         "_id": "Young Peoples Fund - National Grants",
         "code": "YPN1",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YPN2": {
         "_id": "Young Peoples Fund - National Grants",
         "code": "YPN2",
-        "urlPath": "/global-content/programmes/wales/young-peoples-fund-bridging-the-gap"
+        "urlPath": "young-peoples-fund-bridging-the-gap"
     },
     "YIN1": {
         "_id": "Youth Investment Fund",
         "code": "YIN1",
-        "urlPath": "/global-content/programmes/england/youth-investment-fund"
+        "urlPath": "youth-investment-fund"
     },
     "IWF1": {
         "_id": "iwill fund",


### PR DESCRIPTION
This renames all of the links for funding programmes to the new, archived pages, rather than the legacy pages. Pairs with https://github.com/biglotteryfund/blf-alpha/pull/1600