### PR TITLE
[WIP] Add tests for import process

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "sls offline start --dontPrintOutput",
-    "test": "eslint . && jest --detectOpenHandles",
+    "test": "eslint . && jest --detectOpenHandles --testPathIgnorePatterns compare-facets.test.js",
     "format": "prettier --single-quote --write *.js *.yml {grants,lib}/**/*.js README.md",
     "deployTest": "sls deploy --stage=test --region=eu-west-2",
     "deployProd": "sls deploy --stage=prod --region=eu-west-2"

--- a/scripts/verify-data
+++ b/scripts/verify-data
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+DATABASE_NAME=$1
+COLLECTION_NAME=$2
+
+if [ -z "$1" ]
+  then
+    echo "First argument should be the database to use"
+    exit 1
+fi
+
+if [ -z "$2" ]
+  then
+    echo "Second argument should be a collection name to import into"
+    exit 1
+fi
+
+
+echo "Looking up current live facet data..."
+curl --silent https://lambda.blf.digital/past-grants-search/build-facets > facets-old.json
+echo "Done."
+echo "Computing new facet data based on this import..."
+export MONGO_DB=$DATABASE_NAME && export MONGO_COLLECTION=$COLLECTION_NAME && sls offline start --exec="curl --silent http://localhost:8888/past-grants-search/build-facets > facets-new.json"
+echo "Done."
+echo "Running tests to ensure major facets have not changed"
+jest ./test/compare-facets.test.js;
+rm facets-old.json facets-new.json
+echo "Tests complete. If any tests failed, ensure your changes did not introduce any unexpected new data."

--- a/test/compare-facets.test.js
+++ b/test/compare-facets.test.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+/* eslint-env jest */
+'use strict';
+
+const facetsOld = require('../facets-old');
+const facetsNew = require('../facets-new');
+
+describe('Grants import process', () => {
+
+    it('should not introduce new countries (or remove existing ones)', () => {
+        expect(facetsNew.resultsEn.countries.length).toEqual(facetsOld.resultsEn.countries.length);
+    });
+
+    it('should not retroactively add past grants', () => {
+        expect(facetsNew.resultsEn.awardDate.find(_ => _._id === 2018).count).toEqual(facetsOld.resultsEn.awardDate.find(_ => _._id === 2018).count);
+    });
+
+    it('should not modify the number of Westminster Constituencies', () => {
+        expect(facetsNew.resultsEn.westminsterConstituencies.length).toEqual(facetsOld.resultsEn.westminsterConstituencies.length);
+        expect(facetsNew.resultsEn.westminsterConstituencies.length).toBeLessThanOrEqual(650); // current number of constituencies
+    });
+
+    it('should not modify the number of Local Authorities', () => {
+        expect(facetsNew.resultsEn.localAuthorities.length).toEqual(facetsOld.resultsEn.localAuthorities.length);
+        expect(facetsNew.resultsEn.localAuthorities.length).toBeLessThanOrEqual(418); // current number of local authorities
+    });
+
+});


### PR DESCRIPTION
This approach is a bit unusual so curious on your thoughts @davidrapson.

Basically, the point here is to test that newly-imported grant data doesn't introduce unexpected things (eg. in January we inadvertently broke the local authority search by incorrectly parsing new data and adding a bunch of new locations which weren't LAs).

It does this by requesting the currently-live facets, generating new facets based on the new data, and running some comparison tests against the two.

The test script would need to be run during the import process (eg. at the end) as a kind of smoke test – it doesn't really fit into the regular test paradigm as it's a kind of a one-off that's tied to the (manual) import task.

Thoughts/ideas welcome!