### PR TITLE
Fix IDs

### DIFF
--- a/data/fundingProgrammes.js
+++ b/data/fundingProgrammes.js
@@ -1217,5 +1217,19 @@ module.exports = {
         "_id": "Lived Experience Leadership Pilot",
         "code": "LEL1",
         "urlPath": "leaders-with-lived-experience"
+    },
+    "25A1": {
+        "_id": "25th Anniversary",
+        "code": "25A1"
+    },
+    "GRI1": {
+        "_id": "NI Great Ideas",
+        "code": "GRI1",
+        "urlPath": "great-ideas"
+    },
+    "STF1": {
+        "_id": "Safeguarding Training Fund",
+        "code": "STF1",
+        "urlPath": "safeguarding-training-fund-phase-1"
     }
 };

--- a/grants/search.js
+++ b/grants/search.js
@@ -19,13 +19,6 @@ const { GEOCODE_TYPES } = require('../lib/geocodes');
 const { getTranslation, translateLabels } = require('../translations');
 const { matchPostcode, numberWithCommas } = require('../lib/strings');
 
-/**
- * 360Giving organisation prefix
- * We don't want to expose this in public urls
- * so we prepend this when doing lookups
- */
-const ID_PREFIX = '360G-blf-';
-
 const now = moment();
 const URL_DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -791,15 +784,7 @@ async function fetchGrants(mongo, locale = 'en', queryParams) {
             ? { $project: { _id: 0 } }
             : null,
 
-        { $sort: sort.criteria },
-
-        {
-            $addFields: {
-                id: {
-                    $arrayElemAt: [{ $split: ['$id', ID_PREFIX] }, 1]
-                }
-            }
-        }
+        { $sort: sort.criteria }
     ]);
 
     /**
@@ -933,14 +918,7 @@ async function fetchGrantByRecipient(
      */
     const resultsPipeline = [
         { $match: matchCriteria },
-        { $sort: { 'awardDate': -1, 'recipientOrganization.id': 1 } },
-        {
-            $addFields: {
-                id: {
-                    $arrayElemAt: [{ $split: ['$id', ID_PREFIX] }, 1]
-                }
-            }
-        }
+        { $sort: { 'awardDate': -1, 'recipientOrganization.id': 1 } }
     ];
 
     let grantsResult = await grantsCollection
@@ -1008,8 +986,7 @@ async function fetchGrantByRecipient(
  * so we prepend this when doing lookups
  */
 async function fetchGrantById(collection, id, locale = 'en') {
-    const fullID = `${ID_PREFIX}${id}`;
-    let result = await collection.findOne({ id: fullID });
+    let result = await collection.findOne({ id: id });
     result = result && addGrantDetail(result, locale);
     return result;
 }

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -184,7 +184,6 @@ const renameFields = data => {
 
         if (locationName) {
             let locationData = {
-                name: locationName,
                 geoCode: locationCode
             };
 
@@ -193,9 +192,11 @@ const renameFields = data => {
             const codeType = locationsByCode.find(l => l.code === locationCode);
             if (codeType) {
                 locationData['geoCodeType'] = codeType.type;
+                locationData['name'] = codeType.name;
             } else if (num === 0) {
                 // the first codes are normally wards
                 locationData['geoCodeType'] = GEOCODE_TYPES.ward;
+                locationData['name'] = locationName;
             }
 
             // Add the country name (if valid) for later filtering

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -120,6 +120,17 @@ const separateOrgType = data => {
     return data;
 };
 
+/**
+ * Remove 360Giving organisation prefixes
+ * (we have two due to name change)
+ * We don't want to expose these IDs in public urls
+ * so we remove them at import time
+ */
+function trimIdPrefix(id) {
+    const ID_PREFIX = /360G-(blf|tnlcomfund)-/;
+    return id.replace(ID_PREFIX, '');
+}
+
 // Rename the fields to something more useful and drop unused fields
 // http://standard.threesixtygiving.org/en/latest/_static/docson/index.html#../360-giving-schema.json
 const renameFields = data => {
@@ -131,7 +142,8 @@ const renameFields = data => {
     }
 
     const newData = {
-        id: data['Identifier'],
+        id: trimIdPrefix(data['Identifier']),
+        originalId: data['Identifier'],
         title: data['Title'],
         description: data['Description'],
         currency: data['Currency'],

--- a/scripts/modules/helpers.js
+++ b/scripts/modules/helpers.js
@@ -11,13 +11,16 @@ let locationsByCode = [];
 wardLocations.forEach(l => {
     locationsByCode.push({
         code: l.wardCode,
-        type: GEOCODE_TYPES.ward
+        type: GEOCODE_TYPES.ward,
+        name: l.wardName,
     }, {
         code: l.constituencyCode,
-        type: GEOCODE_TYPES.constituency
+        type: GEOCODE_TYPES.constituency,
+        name: l.constituencyName
     }, {
         code: l.localAuthorityCode,
-        type: GEOCODE_TYPES.localAuthority
+        type: GEOCODE_TYPES.localAuthority,
+        name: l.localAuthorityName,
     });
 });
 


### PR DESCRIPTION
The switchover from BLF to TNLCF has changed our 360Giving IDs, which mean the data imported after the name change no longer has valid URLs.

This change moves the ID rewriting to the import stage rather than Mongo dynamically splitting/replacing IDs on the fly for every query. It also addes a regex to remove both prefixes (eg. ` /360G-(blf|tnlcomfund)-/`) and preserves the original ID, just in case.

This also corresponds to a new data import which adds new funding data (!) but also adds the above newly-formed `id` field. There's a deploy race condition here – when this change goes live, existing grant URLs will all fail (because a lookup for ID 123 used to be prefixed `360G-blf-` as the old data reflects), but I've already uploaded the new data to Mongo so we can quickly cut over to it basically instantly (thanks, Lambda!) so this shouldn't affect anyone.