### PR TITLE
Upgrade travis node version to 10.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 # Defaults
 language: node_js
-node_js: '8'
-
-# Install npm 6
-before_install: npm i -g npm@6
+node_js: '10'
 
 # Install dependencies
 install: npm ci --quiet --prefer-offline


### PR DESCRIPTION
Lambda is already using Node 10, but travis was out of sync.
Upgrading this allows other dev dependencies to be upgraded as many are now dropping node 8 support since it is EOL.