### PR TITLE
Clean up organisation type field

### DIFF
--- a/lib/indices.js
+++ b/lib/indices.js
@@ -54,7 +54,6 @@ module.exports = [
             'beneficiaryLocation.geoCode': 1,
             'beneficiaryLocation.geoCodeType': 1,
             'recipientOrganization.organisationType': 1,
-            'recipientOrganization.organisationSubtype': 1,
         },
         options: {
             name: 'FacetIndex',

--- a/scripts/clean-grant-data
+++ b/scripts/clean-grant-data
@@ -65,8 +65,12 @@ const parseDates = data => {
 
 // Split organisation strings into proper structures
 const separateOrgType = data => {
+    // Format used in oldest data
     const orgTypeKey = 'BIGField_Organisation_Type';
+    // Format used in newer data
     const orgTypeKeyNew = 'BIGField:Organisation Type';
+    // Format used in post-GMS data (phew!)
+    const orgTypeKeyFinal = 'Recipient Org:Organisation Type';
 
     // Older records (pre-2019) used a single field for this (`BIGField_Organisation_Type`)
     // but newer ones split it like so: `BIGField:Organisation Type:Charity`
@@ -106,16 +110,15 @@ const separateOrgType = data => {
         });
     }
 
+    // Now we've normalised each record into having a consistent label/value,
+    // we can clean the weird strings into something consistent
     if (data[orgTypeKey]) {
-        data.organisationType = data[orgTypeKey];
+        // Replace the space around the colon with normal grammar
+        data.organisationType = data[orgTypeKey].replace(' : ', ': ');
         delete data[orgTypeKey];
-
-        const parts = data.organisationType.split(' : ');
-
-        if (parts.length > 1) {
-            data.organisationType = parts[0];
-            data.organisationSubtype = parts[1];
-        }
+    } else if (data[orgTypeKeyFinal]) {
+        // If it uses the new format we don't need to do anything except assign it
+        data.organisationType = data[orgTypeKeyFinal];
     }
     return data;
 };
@@ -162,7 +165,6 @@ const renameFields = data => {
             companyNumber: data['Recipient Org:Company Number'] || undefined,
             // @TODO https://github.com/OpenDataServices/grantnav/issues/490
             organisationType: data['organisationType'],
-            organisationSubtype: data['organisationSubtype']
         },
         fundingOrganization: {
             id: data['Funding Org:Identifier'],
@@ -370,7 +372,7 @@ getStream().pipe(es.mapSync((data) => {
             data[programme.code] = {
                 '_id': programme.title,
                 'code': programme.code,
-                'urlPath': '/relative/url/goes/here'
+                'urlPath': 'funding-programme-slug-in-cms-goes-here'
             };
         });
         console.log(JSON.stringify(data, null, 4));

--- a/scripts/verify-data
+++ b/scripts/verify-data
@@ -20,7 +20,8 @@ echo "Looking up current live facet data..."
 curl --silent --max-time 120 https://lambda.blf.digital/past-grants-search/build-facets > facets-old.json
 echo "Done."
 echo "Computing new facet data based on this import..."
-export MONGO_DB=$DATABASE_NAME && export MONGO_COLLECTION=$COLLECTION_NAME && sls offline start --exec="curl --silent http://localhost:8888/past-grants-search/build-facets > facets-new.json"
+echo "(Ensure you have the app running on localhost:8888 so we can fetch the data)"
+export MONGO_DB=$DATABASE_NAME && export MONGO_COLLECTION=$COLLECTION_NAME && curl --silent http://localhost:8888/past-grants-search/build-facets > facets-new.json
 echo "Done."
 echo "Running tests to ensure major facets have not changed"
 jest ./test/compare-facets.test.js;


### PR DESCRIPTION
Fixed https://github.com/biglotteryfund/blf-alpha/issues/3527 – the new GMS data drops the concept of sub-types for organisations, so this change removes it and makes the filter/facet a single-level rather than nested, eg:

## Before:

![image](https://user-images.githubusercontent.com/394376/87172985-ffdcd180-c2cc-11ea-8e9b-5c94d154493e.png)

## After:
![image](https://user-images.githubusercontent.com/394376/87172950-f3f10f80-c2cc-11ea-9a03-940c528d1559.png)

This matches the format from GMS going forward.