### PR TITLE
exclude data folder from yml to reduce size

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ package:
     - .git/**
     - scripts/**
     - test/**
+    - data/**
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
The files have reached lambdas hard limit and cannot be deployed to. To reduce the file size, we exclude the data folder from the serverless.yml