### PR TITLE
manually set excludedevdependencies to reduce file size

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -20,6 +20,7 @@ package:
     - .git/**
     - scripts/**
     - test/**
+  excludeDevDependencies: true
 
 plugins:
   - serverless-offline


### PR DESCRIPTION
This was previously set by default to true, but appears to be setting to false by default due to the increased file size. 